### PR TITLE
Also replace url encoded paths

### DIFF
--- a/CRM/Mosaicomigration/Form/Migration.php
+++ b/CRM/Mosaicomigration/Form/Migration.php
@@ -145,14 +145,20 @@ class CRM_Mosaicomigration_Form_Migration extends CRM_Core_Form {
    */
   function replacePath() {
     $currentPath = $this->_currentValue;
+    $currentPathEncode = $this->_currentValueNameEncode;
     $newPath = $this->_newValue;
+    $newPathEncode = $this->_newValueNameEncode;
     $sqls = [];
     $sqls[] = "UPDATE civicrm_mosaico_template SET metadata = REPLACE(metadata, %1, %2)";
     $sqls[] = "UPDATE civicrm_mosaico_template SET html = REPLACE(html, %1, %2)";
+    $sqls[] = "UPDATE civicrm_mosaico_template SET html = REPLACE(html, %3, %4)";
     $sqls[] = "UPDATE civicrm_mailing SET body_html = REPLACE(body_html, %1, %2)";
+    $sqls[] = "UPDATE civicrm_mailing SET body_html = REPLACE(body_html, %3, %4)";
     $queryParams = [
       1 => [$currentPath, 'String'],
       2 => [$newPath, 'String'],
+      3 => [$currentPathEncode, 'String'],
+      4 => [$newPathEncode, 'String'],
     ];
     foreach ($sqls as $sql) {
       CRM_Core_DAO::executeQuery($sql, $queryParams);


### PR DESCRIPTION
The extension only replaces unencoded paths e.g. `sites/default/files`. Sometimes these paths are encoded e.g. `sites%2Fdefault%2Ffiles`. We should replace the encoded version too.