### PR TITLE
Don't presume template path contains uk.co.vedaconsulting.mosaico

### DIFF
--- a/CRM/Mosaicomigration/Form/Migration.php
+++ b/CRM/Mosaicomigration/Form/Migration.php
@@ -93,7 +93,7 @@ class CRM_Mosaicomigration_Form_Migration extends CRM_Core_Form {
   function replaceJsonData() {
     $currentValue = $this->_currentValue;
     $newValue = $this->_newValue;
-    $selectSQL = "SELECT * FROM `civicrm_mailing` WHERE `template_options` LIKE '%uk.co.vedaconsulting.mosaico%'";
+    $selectSQL = "SELECT * FROM `civicrm_mailing` WHERE `template_options` LIKE '%mosaicoTemplate%'";
     $dao = CRM_Core_DAO::executeQuery($selectSQL);
     while ($dao->fetch()) {
       $templateOptions = json_decode($dao->template_options, TRUE);


### PR DESCRIPTION
The SQL is hard coded to filter by templates that include the string 'uk.co.vedaconsulting.mosaico'. However, this might not be the case if the extension is saved in a different directory. Rather than relying on this string it would be better to use a more generic string such as 'mosaicoTemplate' that appears in every Mosaico mailing regardless of where the extension is installed.